### PR TITLE
Print metadata of visited music files

### DIFF
--- a/populate.go
+++ b/populate.go
@@ -1,15 +1,17 @@
 package main
 
 import (
-	"os"
 	"fmt"
+	"os"
 	"path/filepath"
+
+	"github.com/dhowden/tag"
 	_ "github.com/lib/pq"
 )
 
 const (
-	DB_USER = "cadence"
-	DB_NAME = "cadence"
+	DB_USER   = "cadence"
+	DB_NAME   = "cadence"
 	MUSIC_DIR = "/home/ken/cadence_testdir/"
 )
 

--- a/populate.go
+++ b/populate.go
@@ -36,6 +36,12 @@ func main() {
 		if e != nil {
 			return e
 		}
+
+		// Read metadata from the file
+		tags, er := tag.ReadFrom(file)
+		if er != nil {
+			return er
+		}
 		return nil
 	})
 

--- a/populate.go
+++ b/populate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/dhowden/tag"
 	_ "github.com/lib/pq"
@@ -31,6 +32,7 @@ func main() {
 		}
 		fmt.Printf("Visited file: %q\n", path)
 
+		// Skip directories
 		if info.IsDir() {
 			return nil
 		}

--- a/populate.go
+++ b/populate.go
@@ -52,6 +52,9 @@ func main() {
 			tags.Album(),
 			tags.Artist(),
 			tags.Genre())
+
+		// Close the file
+		file.Close()
 		return nil
 	})
 

--- a/populate.go
+++ b/populate.go
@@ -17,6 +17,12 @@ const (
 )
 
 func main() {
+	var extensions = [...]string{
+		".mp3",
+		".m4a",
+		".ogg",
+		".flac"}
+
 	// Check if MUSIC_DIR exists. Return if err
 	if _, err := os.Stat(MUSIC_DIR); err != nil {
 		if os.IsNotExist(err) {

--- a/populate.go
+++ b/populate.go
@@ -42,6 +42,12 @@ func main() {
 		if er != nil {
 			return er
 		}
+
+		fmt.Printf("title %q, album %q, artist %q, genre %q.\n",
+			tags.Title(),
+			tags.Album(),
+			tags.Artist(),
+			tags.Genre())
 		return nil
 	})
 

--- a/populate.go
+++ b/populate.go
@@ -43,6 +43,18 @@ func main() {
 			return nil
 		}
 
+		// Skip non-music files
+		music := false
+		for _, ext := range extensions {
+			if strings.HasSuffix(path, ext) {
+				music = true
+				break
+			}
+		}
+		if !music {
+			return nil
+		}
+
 		// Open a file for reading
 		file, e := os.Open(path)
 		if e != nil {

--- a/populate.go
+++ b/populate.go
@@ -31,6 +31,10 @@ func main() {
 		}
 		fmt.Printf("Visited file: %q\n", path)
 
+		if info.IsDir() {
+			return nil
+		}
+
 		// Open a file for reading
 		file, e := os.Open(path)
 		if e != nil {

--- a/populate.go
+++ b/populate.go
@@ -30,6 +30,12 @@ func main() {
 			return err
 		}
 		fmt.Printf("Visited file: %q\n", path)
+
+		// Open a file for reading
+		file, e := os.Open(path)
+		if e != nil {
+			return e
+		}
 		return nil
 	})
 


### PR DESCRIPTION
Files which aren't directories and whose extensions are on the whitelist of extensions (the same list as in the legacy server and the awful populator) have their tags checked, and have metadata about them printed.

Metadata information is fetched using the [tag library](https://github.com/dhowden/tag).