### PR TITLE
Implement first-pass database insertion

### DIFF
--- a/populate.go
+++ b/populate.go
@@ -22,6 +22,15 @@ func main() {
 
 	MUSIC_DIR := os.Args[1]
 
+	// Check if server default-config.ini exists. Return if err
+	// If that file does not exist, we are not looking at a valid cadence-server instance
+	if _, err := os.Stat(filepath.Join(os.Args[2], "default-config.ini")); err != nil {
+		if os.IsNotExist(err) {
+			fmt.Printf("%s is not a valid cadence-server install directory.\n", os.Args[2])
+			return
+		}
+	}
+
 	// Load the configuration from cadence-server
 	// By loading the override file second, it overrides the defaults file automatically.
 	cfg, err := ini.LooseLoad(filepath.Join(os.Args[2], "default-config.ini"),

--- a/populate.go
+++ b/populate.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"database/sql"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -112,13 +113,37 @@ func main() {
 			tags.Genre(),
 			tags.Year())
 
-		// Todo: connect to database
+		// Connect to the database
+		// First, set up the connection string
+		// By necessity, we need to parse out the encryption setting
+		sslmode := "disable"
+		setting := sec.Key("db_encrypt").String()
+		if setting=="yes" || setting=="on" or setting=="1" {
+			sslmode="require"
+		}
+
+		// Now, check for None timeout
+		timeout := sec.Key("db_timeout").String()
+		if timeout=="None" {
+			timeout="0"
+		}
+
+		// Format our values into the connection string
+		connect := fmt.Sprintf("host=%s port=%s user=%s password='%s' dbname=%s"+
+			"sslmode=%s connect_timeout=%s",
+			sec.Key("db_host").String(),
+			sec.Key("db_port").String(),
+			sec.Key("db_username").String(),
+			sec.Key("db_password").String(),
+			sec.Key("db_name").String(),
+			sslmode,
+			timeout)
 
 		// Insert into database
-		//_, err = db.Exec(SQLINSERT, tags.Title(), tags.Album(), tags.Artist(), tags.Genre(), tags.Year(), path)
-		//if err != nil {
-		//		panic(err)
-		//	}
+		_, err = db.Exec(SQLINSERT, tags.Title(), tags.Album(), tags.Artist(), tags.Genre(), tags.Year(), path)
+		if err != nil {
+			panic(err)
+		}
 
 		// Close the file
 		file.Close()

--- a/populate.go
+++ b/populate.go
@@ -32,10 +32,12 @@ func main() {
 
 	// Load the configuration from cadence-server
 	// By loading the override file second, it overrides the defaults file automatically.
-	cfg, err := ini.LooseLoad(filepath.Join(os.Args[2], "default-config.ini"),
+	cfg, err := ini.LoadSources(ini.LoadOptions{Loose: true,
+		AllowPythonMultilineValues: true},
+		filepath.Join(os.Args[2], "default-config.ini"),
 		filepath.Join(os.Args[2], "config.ini"))
 	if err != nil {
-		fmt.Println("Error during config read.")
+		fmt.Println("Error during config read - %v.", err)
 		return
 	}
 

--- a/populate.go
+++ b/populate.go
@@ -48,7 +48,8 @@ func main() {
 		return
 	}
 
-	SQLINSERT := fmt.Sprintf("INSERT INTO %s (%s, %s, %s, %s, %s, %s) VALUES ($1, $2, $3, $4, $5, $6)",
+	SQLINSERT := fmt.Sprintf("INSERT INTO %s (%s, %s, %s, %s, %s, %s) VALUES "+
+		"($1, $2, $3, $4, $5, $6) WHERE NOT EXISTS (SELECT path from cadence WHERE path=$6)",
 		sec.Key("db_table").String(), sec.Key("db_column_title").String(),
 		sec.Key("db_column_album").String(), sec.Key("db_column_artist").String(),
 		sec.Key("db_column_genre").String(), sec.Key("db_column_year").String(),

--- a/populate.go
+++ b/populate.go
@@ -57,8 +57,6 @@ func main() {
 		sec.Key("db_column_path").String(), sec.Key("db_column_path").String(),
 		sec.Key("db_table").String(), sec.Key("db_column_path").String())
 
-	fmt.Println(SQLINSERT)
-
 	var extensions = [...]string{
 		".mp3",
 		".m4a",

--- a/populate.go
+++ b/populate.go
@@ -48,8 +48,9 @@ func main() {
 		return
 	}
 
-	SQLINSERT := fmt.Sprintf("INSERT INTO %s (%s, %s, %s, %s, %s, %s) VALUES "+
-		"($1, $2, $3, $4, $5, $6) WHERE NOT EXISTS (SELECT %s FROM %s WHERE %s=$6)",
+	SQLINSERT := fmt.Sprintf("INSERT INTO %s (%s, %s, %s, %s, %s, %s) SELECT "+
+		"$1, $2, $3, $4, $5, $6::VARCHAR WHERE NOT EXISTS "+
+		"(SELECT %s FROM %s WHERE %s=$6)",
 		sec.Key("db_table").String(), sec.Key("db_column_title").String(),
 		sec.Key("db_column_album").String(), sec.Key("db_column_artist").String(),
 		sec.Key("db_column_genre").String(), sec.Key("db_column_year").String(),
@@ -156,7 +157,8 @@ func main() {
 			tags.Year())
 
 		// Insert into database
-		_, err = db.Exec(SQLINSERT, tags.Title(), tags.Album(), tags.Artist(), tags.Genre(), tags.Year(), path)
+		_, err = db.Exec(SQLINSERT, tags.Title(), tags.Album(), tags.Artist(),
+			tags.Genre(), tags.Year(), path)
 		if err != nil {
 			panic(err)
 		}

--- a/populate.go
+++ b/populate.go
@@ -67,7 +67,7 @@ func main() {
 	}
 
 	// Recursive walk on MUSIC_DIR's contents
-	err := filepath.Walk(MUSIC_DIR, func(path string, info os.FileInfo, err error) error {
+	err = filepath.Walk(MUSIC_DIR, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}

--- a/populate.go
+++ b/populate.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"database/sql"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -51,6 +50,8 @@ func main() {
 		sec.Key("db_column_album").String(), sec.Key("db_column_artist").String(),
 		sec.Key("db_column_genre").String(), sec.Key("db_column_year").String(),
 		sec.Key("db_column_path").String())
+
+	fmt.Println(SQLINSERT)
 
 	var extensions = [...]string{
 		".mp3",
@@ -112,10 +113,10 @@ func main() {
 		// Todo: connect to database
 
 		// Insert into database
-		_, err = db.Exec(SQLINSERT, tags.Title(), tags.Album(), tags.Artist(), tags.Genre(), tags.Year(), path)
-		if err != nil {
-			panic(err)
-		}
+		//_, err = db.Exec(SQLINSERT, tags.Title(), tags.Album(), tags.Artist(), tags.Genre(), tags.Year(), path)
+		//if err != nil {
+		//		panic(err)
+		//	}
 
 		// Close the file
 		file.Close()

--- a/populate.go
+++ b/populate.go
@@ -49,11 +49,12 @@ func main() {
 	}
 
 	SQLINSERT := fmt.Sprintf("INSERT INTO %s (%s, %s, %s, %s, %s, %s) VALUES "+
-		"($1, $2, $3, $4, $5, $6) WHERE NOT EXISTS (SELECT path FROM %s WHERE path=$6)",
+		"($1, $2, $3, $4, $5, $6) WHERE NOT EXISTS (SELECT %s FROM %s WHERE %s=$6)",
 		sec.Key("db_table").String(), sec.Key("db_column_title").String(),
 		sec.Key("db_column_album").String(), sec.Key("db_column_artist").String(),
 		sec.Key("db_column_genre").String(), sec.Key("db_column_year").String(),
-		sec.Key("db_column_path").String(), sec.Key("db_table").String())
+		sec.Key("db_column_path").String(), sec.Key("db_column_path").String(),
+		sec.Key("db_table").String(), sec.Key("db_column_path").String())
 
 	fmt.Println(SQLINSERT)
 

--- a/populate.go
+++ b/populate.go
@@ -47,10 +47,10 @@ func main() {
 	}
 
 	SQLINSERT := fmt.Sprintf("INSERT INTO %s (%s, %s, %s, %s, %s, %s) VALUES ($1, $2, $3, $4, $5, $6)",
-		sec.GetKey("db_table"), sec.GetKey("db_column_title"),
-		sec.GetKey("db_column_album"), sec.GetKey("db_column_artist"),
-		sec.GetKey("db_column_genre"), sec.GetKey("db_column_year"),
-		sec.GetKey("db_column_path"))
+		sec.Key("db_table").String(), sec.Key("db_column_title").String(),
+		sec.Key("db_column_album").String(), sec.Key("db_column_artist").String(),
+		sec.Key("db_column_genre").String(), sec.Key("db_column_year").String(),
+		sec.Key("db_column_path").String())
 
 	var extensions = [...]string{
 		".mp3",

--- a/populate.go
+++ b/populate.go
@@ -118,14 +118,14 @@ func main() {
 		// By necessity, we need to parse out the encryption setting
 		sslmode := "disable"
 		setting := sec.Key("db_encrypt").String()
-		if setting=="yes" || setting=="on" or setting=="1" {
-			sslmode="require"
+		if setting == "yes" || setting == "on" || setting == "1" {
+			sslmode = "require"
 		}
 
 		// Now, check for None timeout
 		timeout := sec.Key("db_timeout").String()
-		if timeout=="None" {
-			timeout="0"
+		if timeout == "None" {
+			timeout = "0"
 		}
 
 		// Format our values into the connection string

--- a/populate.go
+++ b/populate.go
@@ -49,11 +49,11 @@ func main() {
 	}
 
 	SQLINSERT := fmt.Sprintf("INSERT INTO %s (%s, %s, %s, %s, %s, %s) VALUES "+
-		"($1, $2, $3, $4, $5, $6) WHERE NOT EXISTS (SELECT path from cadence WHERE path=$6)",
+		"($1, $2, $3, $4, $5, $6) WHERE NOT EXISTS (SELECT path FROM %s WHERE path=$6)",
 		sec.Key("db_table").String(), sec.Key("db_column_title").String(),
 		sec.Key("db_column_album").String(), sec.Key("db_column_artist").String(),
 		sec.Key("db_column_genre").String(), sec.Key("db_column_year").String(),
-		sec.Key("db_column_path").String())
+		sec.Key("db_column_path").String(), sec.Key("db_table").String())
 
 	fmt.Println(SQLINSERT)
 

--- a/populate.go
+++ b/populate.go
@@ -139,6 +139,20 @@ func main() {
 			sslmode,
 			timeout)
 
+		// Use the connect string to acquire a database connection
+		db, err := sql.Open("postgres", connect)
+		if err != nil {
+			panic(err)
+		}
+
+		defer db.Close()
+
+		// For some silly reason, Open doesn't actually open a connection
+		// Ping the connection to make sure it is actually open
+		if err = db.Ping(); err != nil {
+			panic(err)
+		}
+
 		// Insert into database
 		_, err = db.Exec(SQLINSERT, tags.Title(), tags.Album(), tags.Artist(), tags.Genre(), tags.Year(), path)
 		if err != nil {


### PR DESCRIPTION
The populator now connects to the database as configured by a pair of cadence-server config files, and inserts a record for each song it finds in the music directory.

This insertion is done uniquely on a per-path basis - That is, the same file will be passed over if it's already included in the database (even if the metadata changes).

This is the first working version of `cadence-dbp` - That is, this is the first version which is capable of fulfilling its advertised purpose (providing a music database for ARIA). Therefore, I would tag this as Version 1.0.0.

Merging this PR fixes #3.